### PR TITLE
fix: iOS 15 crash

### DIFF
--- a/Sources/UIKitViews/UIKitViewControllerWrapper.swift
+++ b/Sources/UIKitViews/UIKitViewControllerWrapper.swift
@@ -7,7 +7,7 @@ final class UIKitViewControllerWrapper<Content: UIViewController>: UIViewControl
 
 	init(_ content: Content) {
 		self.content = content
-		super.init()
+		super.init(nibName: nil, bundle: nil)
 		content.willMove(toParent: self)
 		addChild(content)
 		content.didMove(toParent: self)


### PR DESCRIPTION
Use of unimplemented initializer 'init(nibName:bundle:)' for class 'UIKitViews.UIKitViewControllerWrapper'

while iOS 17 will not crash

<img width="1786" alt="iShot_2024-06-26_16 22 20" src="https://github.com/dankinsoid/UIKitViews/assets/10215098/aaeb86fb-f02d-44c8-a908-be38a69a857a">
